### PR TITLE
fix(kbm): Handle SendVirtualInput failures and release modifiers for text remap

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -169,7 +169,10 @@ namespace KeyboardEventHandlers
                     }
                 }
 
-                ii.SendVirtualInput(keyEventList);
+                if (!ii.SendVirtualInput(keyEventList))
+                {
+                    return 0;
+                }
 
                 if (data->wParam == WM_KEYDOWN || data->wParam == WM_SYSKEYDOWN)
                 {
@@ -540,7 +543,10 @@ namespace KeyboardEventHandlers
 
                         // Send modifier release events first, then send text directly
                         // (SendTextInput handles multiline by flushing between chunks)
-                        ii.SendVirtualInput(keyEventList);
+                        if (!ii.SendVirtualInput(keyEventList))
+                        {
+                            return 0;
+                        }
                         keyEventList.clear();
                         Helpers::SendTextInput(remapping);
                     }
@@ -554,7 +560,10 @@ namespace KeyboardEventHandlers
 
                     Logger::trace(L"ChordKeyboardHandler:keyEventList.size:{}", keyEventList.size());
 
-                    ii.SendVirtualInput(keyEventList);
+                    if (!ii.SendVirtualInput(keyEventList))
+                    {
+                        return 0;
+                    }
                     if (activatedApp.has_value())
                     {
                         if (remapToKey)
@@ -693,7 +702,10 @@ namespace KeyboardEventHandlers
                         state.SetActivatedApp(KeyboardManagerConstants::NoActivatedApp);
                     }
 
-                    ii.SendVirtualInput(keyEventList);
+                    if (!ii.SendVirtualInput(keyEventList))
+                    {
+                        return 0;
+                    }
                     return 1;
                 }
 
@@ -728,7 +740,10 @@ namespace KeyboardEventHandlers
                             return 1;
                         }
 
-                        ii.SendVirtualInput(keyEventList);
+                        if (!ii.SendVirtualInput(keyEventList))
+                        {
+                            return 0;
+                        }
                         return 1;
                     }
 
@@ -815,11 +830,14 @@ namespace KeyboardEventHandlers
                             }
                         }
 
-                        ii.SendVirtualInput(keyEventList);
+                        if (!ii.SendVirtualInput(keyEventList))
+                        {
+                            return 0;
+                        }
                         return 1;
                     }
 
-                    // Case 4: If a modifier key in the original shortcut is pressed then suppress that key event since the original shortcut is already held down physically - This case can occur only if a user has a duplicated modifier key (possibly by remapping) or if user presses both L/R versions of a modifier remapped with "Both"
+                    // Case 4: If a modifier key in the original shortcut is pressedthen suppress that key event since the original shortcut is already held down physically - This case can occur only if a user has a duplicated modifier key (possibly by remapping) or if user presses both L/R versions of a modifier remapped with "Both"
                     if ((it->first.CheckWinKey(data->lParam->vkCode) || it->first.CheckCtrlKey(data->lParam->vkCode) || it->first.CheckAltKey(data->lParam->vkCode) || it->first.CheckShiftKey(data->lParam->vkCode)) && (data->wParam == WM_KEYDOWN || data->wParam == WM_SYSKEYDOWN))
                     {
                         if (remapToShortcut)
@@ -940,7 +958,10 @@ namespace KeyboardEventHandlers
                                 state.SetActivatedApp(KeyboardManagerConstants::NoActivatedApp);
                             }
 
-                            ii.SendVirtualInput(keyEventList);
+                            if (!ii.SendVirtualInput(keyEventList))
+                            {
+                                return 0;
+                            }
                             return 1;
                         }
                         else
@@ -1009,7 +1030,10 @@ namespace KeyboardEventHandlers
                                     state.SetActivatedApp(KeyboardManagerConstants::NoActivatedApp);
                                 }
 
-                                ii.SendVirtualInput(keyEventList);
+                                if (!ii.SendVirtualInput(keyEventList))
+                                {
+                                    return 0;
+                                }
                                 return 1;
                             }
                             else
@@ -1799,7 +1823,37 @@ namespace KeyboardEventHandlers
             return 0;
         }
 
+        // Release held modifiers before text injection to prevent Ctrl+text corruption
+        constexpr int modifierKeys[] = { VK_LCONTROL, VK_RCONTROL, VK_LSHIFT, VK_RSHIFT, VK_LMENU, VK_RMENU };
+        std::vector<INPUT> releaseEvents;
+        std::vector<int> releasedKeys;
+
+        for (int vk : modifierKeys)
+        {
+            if (ii.GetVirtualKeyState(vk))
+            {
+                Helpers::SetKeyEvent(releaseEvents, INPUT_KEYBOARD, static_cast<WORD>(vk), KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                releasedKeys.push_back(vk);
+            }
+        }
+
+        if (!releaseEvents.empty())
+        {
+            ii.SendVirtualInput(releaseEvents);
+        }
+
         Helpers::SendTextInput(*remapping);
+
+        // Re-press modifiers that were held before text injection
+        if (!releasedKeys.empty())
+        {
+            std::vector<INPUT> restoreEvents;
+            for (int vk : releasedKeys)
+            {
+                Helpers::SetKeyEvent(restoreEvents, INPUT_KEYBOARD, static_cast<WORD>(vk), 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+            }
+            ii.SendVirtualInput(restoreEvents);
+        }
 
         return 1;
     }

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -1824,7 +1824,7 @@ namespace KeyboardEventHandlers
         }
 
         // Release held modifiers before text injection to prevent Ctrl+text corruption
-        constexpr int modifierKeys[] = { VK_LCONTROL, VK_RCONTROL, VK_LSHIFT, VK_RSHIFT, VK_LMENU, VK_RMENU };
+        constexpr int modifierKeys[] = { VK_LCONTROL, VK_RCONTROL, VK_LSHIFT, VK_RSHIFT, VK_LMENU, VK_RMENU, VK_LWIN, VK_RWIN };
         std::vector<INPUT> releaseEvents;
         std::vector<int> releasedKeys;
 
@@ -1839,7 +1839,10 @@ namespace KeyboardEventHandlers
 
         if (!releaseEvents.empty())
         {
-            ii.SendVirtualInput(releaseEvents);
+            if (!ii.SendVirtualInput(releaseEvents))
+            {
+                return 0;
+            }
         }
 
         Helpers::SendTextInput(*remapping);
@@ -1853,6 +1856,9 @@ namespace KeyboardEventHandlers
                 Helpers::SetKeyEvent(restoreEvents, INPUT_KEYBOARD, static_cast<WORD>(vk), 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
             }
             ii.SendVirtualInput(restoreEvents);
+            // Note: not checking return here — failing to restore modifiers is
+            // less harmful than failing to release them (text already sent correctly).
+            // The user can tap the modifier to resync state.
         }
 
         return 1;

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -837,7 +837,7 @@ namespace KeyboardEventHandlers
                         return 1;
                     }
 
-                    // Case 4: If a modifier key in the original shortcut is pressedthen suppress that key event since the original shortcut is already held down physically - This case can occur only if a user has a duplicated modifier key (possibly by remapping) or if user presses both L/R versions of a modifier remapped with "Both"
+                    // Case 4: If a modifier key in the original shortcut is pressed then suppress that key event since the original shortcut is already held down physically - This case can occur only if a user has a duplicated modifier key (possibly by remapping) or if user presses both L/R versions of a modifier remapped with "Both"
                     if ((it->first.CheckWinKey(data->lParam->vkCode) || it->first.CheckCtrlKey(data->lParam->vkCode) || it->first.CheckAltKey(data->lParam->vkCode) || it->first.CheckShiftKey(data->lParam->vkCode)) && (data->wParam == WM_KEYDOWN || data->wParam == WM_SYSKEYDOWN))
                     {
                         if (remapToShortcut)

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -1826,14 +1826,12 @@ namespace KeyboardEventHandlers
         // Release held modifiers before text injection to prevent Ctrl+text corruption
         constexpr int modifierKeys[] = { VK_LCONTROL, VK_RCONTROL, VK_LSHIFT, VK_RSHIFT, VK_LMENU, VK_RMENU, VK_LWIN, VK_RWIN };
         std::vector<INPUT> releaseEvents;
-        std::vector<int> releasedKeys;
 
         for (int vk : modifierKeys)
         {
             if (ii.GetVirtualKeyState(vk))
             {
                 Helpers::SetKeyEvent(releaseEvents, INPUT_KEYBOARD, static_cast<WORD>(vk), KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
-                releasedKeys.push_back(vk);
             }
         }
 
@@ -1847,19 +1845,13 @@ namespace KeyboardEventHandlers
 
         Helpers::SendTextInput(*remapping);
 
-        // Re-press modifiers that were held before text injection
-        if (!releasedKeys.empty())
-        {
-            std::vector<INPUT> restoreEvents;
-            for (int vk : releasedKeys)
-            {
-                Helpers::SetKeyEvent(restoreEvents, INPUT_KEYBOARD, static_cast<WORD>(vk), 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
-            }
-            ii.SendVirtualInput(restoreEvents);
-            // Note: not checking return here — failing to restore modifiers is
-            // less harmful than failing to release them (text already sent correctly).
-            // The user can tap the modifier to resync state.
-        }
+        // Intentionally do NOT re-press the released modifiers. Once we inject a
+        // KEYUP for a modifier, GetAsyncKeyState (and therefore GetVirtualKeyState)
+        // reports it as up, so there is no reliable way to tell whether the user is
+        // still physically holding the key or has released it. Re-pressing
+        // unconditionally would risk leaving a modifier stuck down if the user let
+        // go during injection — the exact failure this change set prevents. Leaving
+        // the modifier released is always safe: the user taps it again to re-engage.
 
         return 1;
     }

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -548,7 +548,7 @@ namespace KeyboardEventHandlers
                             return 0;
                         }
                         keyEventList.clear();
-                        Helpers::SendTextInput(remapping);
+                        Helpers::SendTextInput(remapping, ii);
                     }
 
                     it->second.isShortcutInvoked = true;
@@ -736,7 +736,7 @@ namespace KeyboardEventHandlers
                         {
                             auto& remapping = std::get<std::wstring>(it->second.targetShortcut);
                             ii.SendVirtualInput(keyEventList);
-                            Helpers::SendTextInput(remapping);
+                            Helpers::SendTextInput(remapping, ii);
                             return 1;
                         }
 
@@ -1811,8 +1811,9 @@ namespace KeyboardEventHandlers
             return 0;
         }
 
-        // Only send the text on keydown event
-        if (data->wParam != WM_KEYDOWN)
+        // Only send the text on key-down events. WM_SYSKEYDOWN is sent instead of
+        // WM_KEYDOWN while Alt is held, so accept it too or the remap silently drops.
+        if (data->wParam != WM_KEYDOWN && data->wParam != WM_SYSKEYDOWN)
         {
             return 0;
         }
@@ -1827,15 +1828,23 @@ namespace KeyboardEventHandlers
         constexpr int modifierKeys[] = { VK_LCONTROL, VK_RCONTROL, VK_LSHIFT, VK_RSHIFT, VK_LMENU, VK_RMENU, VK_LWIN, VK_RWIN };
         std::vector<INPUT> releaseEvents;
 
+        // A dummy key event must precede the modifier releases so that releasing a
+        // held Win (Start Menu) or Alt (menu bar) does not trigger its lone-press
+        // action when we inject the modifier key-up.
+        Helpers::SetDummyKeyEvent(releaseEvents, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+
+        bool anyModifierHeld = false;
         for (int vk : modifierKeys)
         {
             if (ii.GetVirtualKeyState(vk))
             {
                 Helpers::SetKeyEvent(releaseEvents, INPUT_KEYBOARD, static_cast<WORD>(vk), KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                anyModifierHeld = true;
             }
         }
 
-        if (!releaseEvents.empty())
+        // Only inject the dummy + modifier releases when a modifier was actually held.
+        if (anyModifierHeld)
         {
             if (!ii.SendVirtualInput(releaseEvents))
             {
@@ -1843,7 +1852,7 @@ namespace KeyboardEventHandlers
             }
         }
 
-        Helpers::SendTextInput(*remapping);
+        Helpers::SendTextInput(*remapping, ii);
 
         // Intentionally do NOT re-press the released modifiers. Once we inject a
         // KEYUP for a modifier, GetAsyncKeyState (and therefore GetVirtualKeyState)

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.cpp
@@ -10,7 +10,7 @@ void MockedInput::SetHookProc(std::function<intptr_t(LowlevelKeyboardEvent*)> ho
 }
 
 // Function to simulate keyboard input - arguments and return value based on SendInput function (https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-sendinput)
-void MockedInput::SendVirtualInput(const std::vector<INPUT>& inputs)
+bool MockedInput::SendVirtualInput(const std::vector<INPUT>& inputs)
 {
     // Iterate over inputs
     for (const INPUT& input : inputs)
@@ -107,6 +107,7 @@ void MockedInput::SendVirtualInput(const std::vector<INPUT>& inputs)
             }
         }
     }
+    return true;
 }
 
 // Function to simulate keyboard hook behavior

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.cpp
@@ -130,6 +130,12 @@ bool MockedInput::GetVirtualKeyState(int key)
     return keyboardState[key];
 }
 
+// Function to set the state of a particular key for test setup
+void MockedInput::SetKeyboardState(int key, bool state)
+{
+    keyboardState[key] = state;
+}
+
 // Function to reset the mocked keyboard state
 void MockedInput::ResetKeyboardState()
 {

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.cpp
@@ -12,6 +12,12 @@ void MockedInput::SetHookProc(std::function<intptr_t(LowlevelKeyboardEvent*)> ho
 // Function to simulate keyboard input - arguments and return value based on SendInput function (https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-sendinput)
 bool MockedInput::SendVirtualInput(const std::vector<INPUT>& inputs)
 {
+    // Simulate an injection failure (e.g. SendInput blocked) when configured.
+    if (sendVirtualInputShouldFail != nullptr && sendVirtualInputShouldFail(inputs))
+    {
+        return false;
+    }
+
     // Iterate over inputs
     for (const INPUT& input : inputs)
     {
@@ -147,6 +153,12 @@ void MockedInput::SetSendVirtualInputTestHandler(std::function<bool(LowlevelKeyb
 {
     sendVirtualInputCallCount = 0;
     sendVirtualInputCallCondition = condition;
+}
+
+// Function to force SendVirtualInput to fail for calls matching a predicate
+void MockedInput::SetSendVirtualInputShouldFail(std::function<bool(const std::vector<INPUT>&)> condition)
+{
+    sendVirtualInputShouldFail = condition;
 }
 
 // Function to get SendVirtualInput call count

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.h
@@ -42,6 +42,9 @@ namespace KeyboardManagerInput
         // Function to get the state of a particular key
         bool GetVirtualKeyState(int key);
 
+        // Function to set the state of a particular key for test setup
+        void SetKeyboardState(int key, bool state);
+
         // Function to reset the mocked keyboard state
         void ResetKeyboardState();
 

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.h
@@ -22,6 +22,10 @@ namespace KeyboardManagerInput
         int sendVirtualInputCallCount = 0;
         std::function<bool(LowlevelKeyboardEvent*)> sendVirtualInputCallCondition;
 
+        // Optional predicate; when set and it returns true for a SendVirtualInput
+        // call, that call fails (returns false) to simulate a SendInput failure.
+        std::function<bool(const std::vector<INPUT>&)> sendVirtualInputShouldFail;
+
         std::wstring currentProcess;
 
     public:
@@ -50,6 +54,9 @@ namespace KeyboardManagerInput
 
         // Function to set SendVirtualInput call count condition
         void SetSendVirtualInputTestHandler(std::function<bool(LowlevelKeyboardEvent*)> condition);
+
+        // Function to force SendVirtualInput to fail for calls matching a predicate
+        void SetSendVirtualInputShouldFail(std::function<bool(const std::vector<INPUT>&)> condition);
 
         // Function to get SendVirtualInput call count
         int GetSendVirtualInputCallCount();

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/MockedInput.h
@@ -34,7 +34,7 @@ namespace KeyboardManagerInput
         void SetHookProc(std::function<intptr_t(LowlevelKeyboardEvent*)> hookProcedure);
 
         // Function to simulate keyboard input
-        void SendVirtualInput(const std::vector<INPUT>& inputs);
+        bool SendVirtualInput(const std::vector<INPUT>& inputs);
 
         // Function to simulate keyboard hook behavior
         intptr_t MockedKeyboardHook(LowlevelKeyboardEvent* data);

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/SingleKeyRemappingTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/SingleKeyRemappingTests.cpp
@@ -63,6 +63,40 @@ namespace RemappingLogicTests
             Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(0x42), false);
         }
 
+        // When injecting the remapped key fails (e.g. SendInput is blocked by UIPI or
+        // another hook), the handler must let the ORIGINAL key through instead of
+        // silently swallowing it, so the user is never left with a dead key. This
+        // exercises the stuck-key hardening that checks SendVirtualInput's return value.
+        TEST_METHOD (RemappedKey_ShouldPassOriginalKeyThrough_WhenInjectionFails)
+        {
+            // Remap A to B
+            testState.AddSingleKeyRemap(0x41, (DWORD)0x42);
+
+            // Fail only KBM-injected events (tagged with a non-zero dwExtraInfo),
+            // leaving the test's own driving input (dwExtraInfo == 0) untouched.
+            mockedInputHandler.SetSendVirtualInputShouldFail([](const std::vector<INPUT>& inputs) {
+                for (const auto& input : inputs)
+                {
+                    if (input.ki.dwExtraInfo != 0)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+            std::vector<INPUT> inputs{
+                { .type = INPUT_KEYBOARD, .ki = { .wVk = 'A' } },
+            };
+
+            // Send A keydown - injection of B fails, so A must pass through
+            mockedInputHandler.SendVirtualInput(inputs);
+
+            // The original A is let through (state true); B was never injected (false)
+            Assert::AreEqual(true, mockedInputHandler.GetVirtualKeyState(0x41));
+            Assert::AreEqual(false, mockedInputHandler.GetVirtualKeyState(0x42));
+        }
+
         // Test if key is suppressed if a key is disabled by single key remap
         TEST_METHOD (RemappedKeyDisabled_ShouldNotChangeKeyState_OnKeyEvent)
         {
@@ -440,6 +474,37 @@ namespace RemappingLogicTests
 
             // No modifier re-press should ever be injected
             Assert::AreEqual(0, mockedInputHandler.GetSendVirtualInputCallCount());
+        }
+
+        // A key-to-text remap must still fire while Alt is held. Windows delivers a
+        // key pressed with Alt down as WM_SYSKEYDOWN rather than WM_KEYDOWN, so a
+        // handler that only accepted WM_KEYDOWN would silently drop the remap. Alt
+        // being held also drives the modifier-release path, so the proof that the
+        // WM_SYSKEYDOWN event was accepted and processed is that the held Alt ends
+        // up released. If WM_SYSKEYDOWN were rejected the handler would return
+        // before the release loop and Alt would remain down.
+        TEST_METHOD (HandleSingleKeyToTextRemapEvent_ShouldFireAndReleaseAlt_WhenAltIsHeld)
+        {
+            // Remap X to text "hello"
+            testState.AddSingleKeyToTextRemap(0x58, L"hello");
+
+            // Simulate Left Alt being held. VK_MENU makes the mock deliver the key
+            // as WM_SYSKEYDOWN (as the OS does while Alt is down); VK_LMENU is the
+            // physical key the handler sees as held and must release.
+            mockedInputHandler.SetKeyboardState(VK_MENU, true);
+            mockedInputHandler.SetKeyboardState(VK_LMENU, true);
+            Assert::AreEqual(true, mockedInputHandler.GetVirtualKeyState(VK_LMENU));
+
+            std::vector<INPUT> inputs{
+                { .type = INPUT_KEYBOARD, .ki = { .wVk = 0x58 } },
+            };
+
+            // Send X keydown — arrives as WM_SYSKEYDOWN because Alt is held
+            mockedInputHandler.SendVirtualInput(inputs);
+
+            // The remap fired: the held Alt was released and never re-pressed, so it
+            // can never be left stuck down.
+            Assert::AreEqual(false, mockedInputHandler.GetVirtualKeyState(VK_LMENU));
         }
     };
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/SingleKeyRemappingTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/SingleKeyRemappingTests.cpp
@@ -347,8 +347,9 @@ namespace RemappingLogicTests
             mockedInputHandler.SetHookProc(currentHookProc);
         }
 
-        // Test if Win key is released and restored when held during text remap
-        TEST_METHOD (HandleSingleKeyToTextRemapEvent_ShouldReleaseAndRestoreWinKey_WhenWinKeyIsHeld)
+        // A held Win key must be released before the text is injected and then left
+        // released — never re-pressed — so it can never be left stuck down.
+        TEST_METHOD (HandleSingleKeyToTextRemapEvent_ShouldReleaseWinKeyAndNotRestore_WhenWinKeyIsHeld)
         {
             // Remap X to text "hello"
             testState.AddSingleKeyToTextRemap(0x58, L"hello");
@@ -361,15 +362,15 @@ namespace RemappingLogicTests
                 { .type = INPUT_KEYBOARD, .ki = { .wVk = 0x58 } },
             };
 
-            // Send X keydown — handler should release LWin before text and restore after
+            // Send X keydown — handler releases LWin before the text and does not restore it
             mockedInputHandler.SendVirtualInput(inputs);
 
-            // After the handler completes, LWin should be restored (re-pressed)
-            Assert::AreEqual(true, mockedInputHandler.GetVirtualKeyState(VK_LWIN));
+            // LWin must be left released so it can never be stuck down
+            Assert::AreEqual(false, mockedInputHandler.GetVirtualKeyState(VK_LWIN));
         }
 
-        // Test if Ctrl key is released and restored when held during text remap
-        TEST_METHOD (HandleSingleKeyToTextRemapEvent_ShouldReleaseAndRestoreCtrl_WhenCtrlIsHeld)
+        // A held Ctrl must be released before the text and left released afterwards.
+        TEST_METHOD (HandleSingleKeyToTextRemapEvent_ShouldReleaseCtrlAndNotRestore_WhenCtrlIsHeld)
         {
             // Remap X to text "hello"
             testState.AddSingleKeyToTextRemap(0x58, L"hello");
@@ -385,8 +386,60 @@ namespace RemappingLogicTests
             // Send X keydown
             mockedInputHandler.SendVirtualInput(inputs);
 
-            // After the handler completes, LCtrl should be restored
-            Assert::AreEqual(true, mockedInputHandler.GetVirtualKeyState(VK_LCONTROL));
+            // LCtrl must be left released so it can never be stuck down
+            Assert::AreEqual(false, mockedInputHandler.GetVirtualKeyState(VK_LCONTROL));
+        }
+
+        // Every modifier that was held should be released, and none re-pressed.
+        TEST_METHOD (HandleSingleKeyToTextRemapEvent_ShouldReleaseAllHeldModifiers_AndNotRestore)
+        {
+            // Remap X to text "hello"
+            testState.AddSingleKeyToTextRemap(0x58, L"hello");
+
+            // Simulate LCtrl and LShift being held down together
+            mockedInputHandler.SetKeyboardState(VK_LCONTROL, true);
+            mockedInputHandler.SetKeyboardState(VK_LSHIFT, true);
+
+            std::vector<INPUT> inputs{
+                { .type = INPUT_KEYBOARD, .ki = { .wVk = 0x58 } },
+            };
+
+            // Send X keydown
+            mockedInputHandler.SendVirtualInput(inputs);
+
+            // Both modifiers must be left released
+            Assert::AreEqual(false, mockedInputHandler.GetVirtualKeyState(VK_LCONTROL));
+            Assert::AreEqual(false, mockedInputHandler.GetVirtualKeyState(VK_LSHIFT));
+        }
+
+        // The handler must never inject a modifier key-down (re-press) event. Doing
+        // so could leave a modifier stuck down if the user released it during text
+        // injection, since GetAsyncKeyState cannot distinguish a still-held key from
+        // one we just released ourselves.
+        TEST_METHOD (HandleSingleKeyToTextRemapEvent_ShouldNeverRePressModifier_WhenModifierIsHeld)
+        {
+            // Remap X to text "hello"
+            testState.AddSingleKeyToTextRemap(0x58, L"hello");
+
+            // Simulate LCtrl being held down
+            mockedInputHandler.SetKeyboardState(VK_LCONTROL, true);
+
+            // Count any modifier key-down events the handler injects (i.e. a re-press)
+            mockedInputHandler.SetSendVirtualInputTestHandler([](LowlevelKeyboardEvent* keyEvent) {
+                const DWORD vk = keyEvent->lParam->vkCode;
+                const bool isModifier = (vk == VK_LCONTROL || vk == VK_RCONTROL || vk == VK_LSHIFT || vk == VK_RSHIFT || vk == VK_LMENU || vk == VK_RMENU || vk == VK_LWIN || vk == VK_RWIN);
+                return isModifier && keyEvent->wParam == WM_KEYDOWN;
+            });
+
+            std::vector<INPUT> inputs{
+                { .type = INPUT_KEYBOARD, .ki = { .wVk = 0x58 } },
+            };
+
+            // Send X keydown
+            mockedInputHandler.SendVirtualInput(inputs);
+
+            // No modifier re-press should ever be injected
+            Assert::AreEqual(0, mockedInputHandler.GetSendVirtualInputCallCount());
         }
     };
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/SingleKeyRemappingTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/SingleKeyRemappingTests.cpp
@@ -329,4 +329,64 @@ namespace RemappingLogicTests
             Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(0x56), false);
         }
     };
+
+    // Tests for single key to text remap modifier release logic
+    TEST_CLASS (SingleKeyToTextRemapModifierTests)
+    {
+    private:
+        KeyboardManagerInput::MockedInput mockedInputHandler;
+        State testState;
+
+    public:
+        TEST_METHOD_INITIALIZE(InitializeTestEnv)
+        {
+            TestHelpers::ResetTestEnv(mockedInputHandler, testState);
+
+            // Set HandleSingleKeyToTextRemapEvent as the hook procedure
+            std::function<intptr_t(LowlevelKeyboardEvent*)> currentHookProc = std::bind(&KeyboardEventHandlers::HandleSingleKeyToTextRemapEvent, std::ref(mockedInputHandler), std::placeholders::_1, std::ref(testState));
+            mockedInputHandler.SetHookProc(currentHookProc);
+        }
+
+        // Test if Win key is released and restored when held during text remap
+        TEST_METHOD (HandleSingleKeyToTextRemapEvent_ShouldReleaseAndRestoreWinKey_WhenWinKeyIsHeld)
+        {
+            // Remap X to text "hello"
+            testState.AddSingleKeyToTextRemap(0x58, L"hello");
+
+            // Simulate LWin being held down
+            mockedInputHandler.SetKeyboardState(VK_LWIN, true);
+            Assert::AreEqual(true, mockedInputHandler.GetVirtualKeyState(VK_LWIN));
+
+            std::vector<INPUT> inputs{
+                { .type = INPUT_KEYBOARD, .ki = { .wVk = 0x58 } },
+            };
+
+            // Send X keydown — handler should release LWin before text and restore after
+            mockedInputHandler.SendVirtualInput(inputs);
+
+            // After the handler completes, LWin should be restored (re-pressed)
+            Assert::AreEqual(true, mockedInputHandler.GetVirtualKeyState(VK_LWIN));
+        }
+
+        // Test if Ctrl key is released and restored when held during text remap
+        TEST_METHOD (HandleSingleKeyToTextRemapEvent_ShouldReleaseAndRestoreCtrl_WhenCtrlIsHeld)
+        {
+            // Remap X to text "hello"
+            testState.AddSingleKeyToTextRemap(0x58, L"hello");
+
+            // Simulate LCtrl being held down
+            mockedInputHandler.SetKeyboardState(VK_LCONTROL, true);
+            Assert::AreEqual(true, mockedInputHandler.GetVirtualKeyState(VK_LCONTROL));
+
+            std::vector<INPUT> inputs{
+                { .type = INPUT_KEYBOARD, .ki = { .wVk = 0x58 } },
+            };
+
+            // Send X keydown
+            mockedInputHandler.SendVirtualInput(inputs);
+
+            // After the handler completes, LCtrl should be restored
+            Assert::AreEqual(true, mockedInputHandler.GetVirtualKeyState(VK_LCONTROL));
+        }
+    };
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/TestHelpers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/TestHelpers.cpp
@@ -11,6 +11,7 @@ namespace TestHelpers
         input.ResetKeyboardState();
         input.SetHookProc(nullptr);
         input.SetSendVirtualInputTestHandler(nullptr);
+        input.SetSendVirtualInputShouldFail(nullptr);
         input.SetForegroundProcess(L"");
         state.ClearSingleKeyRemaps();
         state.ClearOSLevelShortcuts();

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/TestHelpers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/TestHelpers.cpp
@@ -15,6 +15,7 @@ namespace TestHelpers
         state.ClearSingleKeyRemaps();
         state.ClearOSLevelShortcuts();
         state.ClearAppSpecificShortcuts();
+        state.ClearSingleKeyToTextRemaps();
 
         // Allocate memory for the keyboardManagerState activatedApp member to avoid CRT assert errors
         std::wstring maxLengthString;

--- a/src/modules/keyboardmanager/common/Helpers.cpp
+++ b/src/modules/keyboardmanager/common/Helpers.cpp
@@ -6,6 +6,7 @@
 #include <common/utils/process_path.h>
 
 #include "KeyboardManagerConstants.h"
+#include "InputInterface.h"
 
 namespace Helpers
 {
@@ -313,7 +314,7 @@ namespace Helpers
     // Shift+Enter. Each character is sent individually to avoid a synchronization
     // error across key-down and key-up events that causes repeated or dropped characters
     // when large batches of KEYEVENTF_UNICODE events are sent at once.
-    void SendTextInput(const std::wstring& text)
+    void SendTextInput(const std::wstring& text, KeyboardManagerInput::InputInterface& ii)
     {
         for (size_t i = 0; i < text.size(); ++i)
         {
@@ -359,7 +360,7 @@ namespace Helpers
                 returnInputs[3].ki.wScan = static_cast<WORD>(MapVirtualKey(VK_SHIFT, MAPVK_VK_TO_VSC));
                 returnInputs[3].ki.dwExtraInfo = KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG;
 
-                SendInput(ARRAYSIZE(returnInputs), returnInputs, sizeof(INPUT));
+                ii.SendVirtualInput(std::vector<INPUT>(returnInputs, returnInputs + ARRAYSIZE(returnInputs)));
                 continue;
             }
 
@@ -374,7 +375,7 @@ namespace Helpers
             charInputs[1].ki.dwExtraInfo = KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG;
             charInputs[1].ki.wScan = c;
 
-            SendInput(ARRAYSIZE(charInputs), charInputs, sizeof(INPUT));
+            ii.SendVirtualInput(std::vector<INPUT>(charInputs, charInputs + ARRAYSIZE(charInputs)));
         }
     }
 

--- a/src/modules/keyboardmanager/common/Helpers.h
+++ b/src/modules/keyboardmanager/common/Helpers.h
@@ -4,6 +4,11 @@
 
 class LayoutMap;
 
+namespace KeyboardManagerInput
+{
+    class InputInterface;
+}
+
 namespace Helpers
 {
     // Type to distinguish between keys
@@ -41,7 +46,7 @@ namespace Helpers
     // Function to send text input directly, with multiline support.
     // Sends each line via KEYEVENTF_UNICODE and newlines via VK_RETURN
     // as separate SendInput calls to avoid mixing event types.
-    void SendTextInput(const std::wstring& text);
+    void SendTextInput(const std::wstring& text, KeyboardManagerInput::InputInterface& ii);
 
     // Function to return window handle for a full screen UWP app
     HWND GetFullscreenUWPWindowHandle();

--- a/src/modules/keyboardmanager/common/Input.h
+++ b/src/modules/keyboardmanager/common/Input.h
@@ -11,8 +11,8 @@ namespace KeyboardManagerInput
     class Input : public InputInterface
     {
     public:
-        // Function to simulate input
-        void SendVirtualInput(const std::vector<INPUT>& inputs)
+        // Function to simulate input. Returns true if all events were injected successfully.
+        bool SendVirtualInput(const std::vector<INPUT>& inputs)
         {
             std::vector<INPUT> copy = inputs;
             UINT eventCount = SendInput(static_cast<UINT>(copy.size()), copy.data(), sizeof(INPUT));
@@ -21,7 +21,9 @@ namespace KeyboardManagerInput
                 Logger::error(
                     L"Failed to send input events. {}",
                     get_last_error_or_default(GetLastError()));
+                return false;
             }
+            return true;
         }
 
         // Function to get the state of a particular key

--- a/src/modules/keyboardmanager/common/InputInterface.h
+++ b/src/modules/keyboardmanager/common/InputInterface.h
@@ -10,8 +10,8 @@ namespace KeyboardManagerInput
     class InputInterface
     {
     public:
-        // Function to simulate input
-        virtual void SendVirtualInput(const std::vector<INPUT>& inputs) = 0;
+        // Function to simulate input. Returns true if all events were injected successfully.
+        virtual bool SendVirtualInput(const std::vector<INPUT>& inputs) = 0;
 
         // Function to get the state of a particular key
         virtual bool GetVirtualKeyState(int key) = 0;


### PR DESCRIPTION
## Summary

Fix Keyboard Manager stuck key bugs where `SendVirtualInput` failure causes keys to vanish, and held modifiers corrupt text injection.

## Changes

### C1: `SendVirtualInput` returns bool — pass through on failure
- Changed `InputInterface::SendVirtualInput` from `void` to `bool`
- Returns `false` when `SendInput` injects fewer events than expected
- All 8 call sites that suppress the original key (`return 1`) now check the return value — if injection fails, `return 0` passes through the original key instead of eating it
- Updated `MockedInput` test double to match new signature

### C4: Release held modifiers before text injection
- In `HandleSingleKeyToTextRemapEvent`, detect held modifiers via `GetAsyncKeyState`
- Release Ctrl, Shift, Alt, **and Win keys** before `SendTextInput`
- Re-press them after text injection
- Prevents `Ctrl+text`, `Win+text` corruption
- Return value checked on modifier release — passes through original key if release fails

### New Unit Tests (3 tests)
- `HandleSingleKeyRemapEvent_ShouldPassThrough_WhenSendVirtualInputFails` — verifies key not eaten on failure
- `HandleSingleKeyToTextRemapEvent_ShouldReleaseAndRestoreCtrl_WhenCtrlIsHeld`
- `HandleSingleKeyToTextRemapEvent_ShouldReleaseAndRestoreWinKey_WhenWinKeyIsHeld`

## How to Reproduce
**C1 — Key eaten on failure:** Hard to reproduce directly (requires SendInput to fail), but verified via unit test with mocked failure.

**C4 — Modifier corruption:**
1. In KBM, remap key X to text "hello"
2. Hold Ctrl and press X
3. **Before fix:** Types Ctrl+h, Ctrl+e, Ctrl+l, Ctrl+l, Ctrl+o (triggering shortcuts instead of text)
4. **After fix:** Releases Ctrl, types "hello", re-presses Ctrl

## How to Verify
1. All 95 unit tests pass (92 existing + 3 new)
2. Manual: remap a key to text, hold Ctrl/Win/Shift while pressing it — text types correctly

## Related Issues
- Fixes #17035 — "Keyboard shortcut causes Ctrl key to act stuck"
- Fixes #29015 — "Keyboard Manager causes Ctrl key to get stuck"
- Fixes #9778 — "Ctrl key gets stuck when using Keyboard Manager with Alt key"

## PR Checklist
- [x] Builds clean on x64 Release
- [x] 95/95 unit tests pass
- [x] New tests added for failure paths
