### PR TITLE
fix(poweraccent): Add injection hygiene and focus-loss cleanup

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -207,13 +207,13 @@ public partial class PowerAccent : IDisposable
 
             case InputType.Right:
                 {
-                    SendKeys.SendWait("{RIGHT}");
+                    WindowsFunctions.SendArrowKey(Windows.Win32.UI.Input.KeyboardAndMouse.VIRTUAL_KEY.VK_RIGHT);
                     break;
                 }
 
             case InputType.Left:
                 {
-                    SendKeys.SendWait("{LEFT}");
+                    WindowsFunctions.SendArrowKey(Windows.Win32.UI.Input.KeyboardAndMouse.VIRTUAL_KEY.VK_LEFT);
                     break;
                 }
 

--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -350,6 +350,11 @@ public partial class PowerAccent : IDisposable
         }
     }
 
+    public void ForceResetKeyboardState()
+    {
+        _keyboardListener.ForceReset();
+    }
+
     public void Dispose()
     {
         _keyboardListener.UnInitHook();

--- a/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
@@ -16,7 +16,7 @@ internal static class WindowsFunctions
 {
     // Mirrors PowertoyModuleIface::CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG (0x110) so the
     // centralized keyboard hook ignores the keys PowerAccent injects and they don't re-trigger shortcuts.
-    private const nuint POWERTOYS_INJECTED_TAG = 0x110;
+    private const nuint PowerToysInjectedTag = 0x110;
 
     public static void Insert(string s, bool back = false)
     {
@@ -35,7 +35,7 @@ internal static class WindowsFunctions
                             ki = new KEYBDINPUT
                             {
                                 wVk = VIRTUAL_KEY.VK_BACK,
-                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                                dwExtraInfo = PowerToysInjectedTag,
                             },
                         },
                     },
@@ -48,7 +48,7 @@ internal static class WindowsFunctions
                             {
                                 wVk = VIRTUAL_KEY.VK_BACK,
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
-                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                                dwExtraInfo = PowerToysInjectedTag,
                             },
                         },
                     },
@@ -59,6 +59,7 @@ internal static class WindowsFunctions
                 {
                     Logger.LogError($"SendInput backspace failed: sent {backSent}/{inputsBack.Length}");
                 }
+
                 Thread.Sleep(1); // Some apps, like Terminal, need a little wait to process the sent backspace or they'll ignore it.
             }
 
@@ -76,7 +77,7 @@ internal static class WindowsFunctions
                             {
                                 wScan = c,
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_UNICODE,
-                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                                dwExtraInfo = PowerToysInjectedTag,
                             },
                         },
                     },
@@ -89,7 +90,7 @@ internal static class WindowsFunctions
                             {
                                 wScan = c,
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_UNICODE | KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
-                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                                dwExtraInfo = PowerToysInjectedTag,
                             },
                         },
                     },
@@ -146,7 +147,8 @@ internal static class WindowsFunctions
                         ki = new KEYBDINPUT
                         {
                             wVk = arrowKey,
-                            dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                            dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_EXTENDEDKEY,
+                            dwExtraInfo = PowerToysInjectedTag,
                         },
                     },
                 },
@@ -158,8 +160,8 @@ internal static class WindowsFunctions
                         ki = new KEYBDINPUT
                         {
                             wVk = arrowKey,
-                            dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
-                            dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                            dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_EXTENDEDKEY | KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
+                            dwExtraInfo = PowerToysInjectedTag,
                         },
                     },
                 },

--- a/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 
+using ManagedCommon;
 using Windows.Win32;
 using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
@@ -13,6 +14,10 @@ namespace PowerAccent.Core.Tools;
 
 internal static class WindowsFunctions
 {
+    // Mirrors PowertoyModuleIface::CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG (0x110) so the
+    // centralized keyboard hook ignores the keys PowerAccent injects and they don't re-trigger shortcuts.
+    private const nuint POWERTOYS_INJECTED_TAG = 0x110;
+
     public static void Insert(string s, bool back = false)
     {
         unsafe
@@ -30,6 +35,7 @@ internal static class WindowsFunctions
                             ki = new KEYBDINPUT
                             {
                                 wVk = VIRTUAL_KEY.VK_BACK,
+                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
                             },
                         },
                     },
@@ -42,12 +48,17 @@ internal static class WindowsFunctions
                             {
                                 wVk = VIRTUAL_KEY.VK_BACK,
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
+                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
                             },
                         },
                     },
                 };
 
-                _ = PInvoke.SendInput(inputsBack, Marshal.SizeOf<INPUT>());
+                uint backSent = PInvoke.SendInput(inputsBack, Marshal.SizeOf<INPUT>());
+                if (backSent != (uint)inputsBack.Length)
+                {
+                    Logger.LogError($"SendInput backspace failed: sent {backSent}/{inputsBack.Length}");
+                }
                 Thread.Sleep(1); // Some apps, like Terminal, need a little wait to process the sent backspace or they'll ignore it.
             }
 
@@ -65,6 +76,7 @@ internal static class WindowsFunctions
                             {
                                 wScan = c,
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_UNICODE,
+                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
                             },
                         },
                     },
@@ -77,12 +89,17 @@ internal static class WindowsFunctions
                             {
                                 wScan = c,
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_UNICODE | KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
+                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
                             },
                         },
                     },
                 };
 
-                _ = PInvoke.SendInput(inputsInsert, Marshal.SizeOf<INPUT>());
+                uint charSent = PInvoke.SendInput(inputsInsert, Marshal.SizeOf<INPUT>());
+                if (charSent != (uint)inputsInsert.Length)
+                {
+                    Logger.LogError($"SendInput character failed: sent {charSent}/{inputsInsert.Length}");
+                }
             }
         }
     }
@@ -113,5 +130,46 @@ internal static class WindowsFunctions
     {
         var shift = PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_SHIFT);
         return shift < 0;
+    }
+
+    public static void SendArrowKey(VIRTUAL_KEY arrowKey)
+    {
+        unsafe
+        {
+            var inputs = new INPUT[]
+            {
+                new INPUT
+                {
+                    type = INPUT_TYPE.INPUT_KEYBOARD,
+                    Anonymous = new INPUT._Anonymous_e__Union
+                    {
+                        ki = new KEYBDINPUT
+                        {
+                            wVk = arrowKey,
+                            dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                        },
+                    },
+                },
+                new INPUT
+                {
+                    type = INPUT_TYPE.INPUT_KEYBOARD,
+                    Anonymous = new INPUT._Anonymous_e__Union
+                    {
+                        ki = new KEYBDINPUT
+                        {
+                            wVk = arrowKey,
+                            dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
+                            dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                        },
+                    },
+                },
+            };
+
+            uint arrowSent = PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
+            if (arrowSent != (uint)inputs.Length)
+            {
+                Logger.LogError($"SendInput arrow key failed: sent {arrowSent}/{inputs.Length}");
+            }
+        }
     }
 }

--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
@@ -51,7 +51,13 @@ public partial class Selector : FluentWindow, IDisposable, INotifyPropertyChange
         base.OnSourceInitialized(e);
         _powerAccent.OnChangeDisplay += PowerAccent_OnChangeDisplay;
         _powerAccent.OnSelectCharacter += PowerAccent_OnSelectionCharacter;
+        this.Deactivated += Selector_Deactivated;
         this.Visibility = Visibility.Hidden;
+    }
+
+    private void Selector_Deactivated(object sender, EventArgs e)
+    {
+        _powerAccent.ForceResetKeyboardState();
     }
 
     private void PowerAccent_OnSelectionCharacter(int index, string character)

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -51,6 +51,23 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         }
     }
 
+    void KeyboardListener::ForceReset()
+    {
+        Logger::debug(L"ForceReset: clearing all state");
+        letterPressed = LetterKey::None;
+        m_toolbarVisible = false;
+        m_triggeredWithSpace = false;
+        m_triggeredWithLeftArrow = false;
+        m_triggeredWithRightArrow = false;
+        m_leftShiftPressed = false;
+        m_rightShiftPressed = false;
+
+        if (m_hideToolbarCb)
+        {
+            m_hideToolbarCb(InputType::None);
+        }
+    }
+
     void KeyboardListener::SetShowToolbarEvent(ShowToolbar showToolbarEvent)
     {
         m_showToolbarCb = [trigger = std::move(showToolbarEvent)](LetterKey key) {

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -204,7 +204,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
             if (std::find(std::begin(triggers), end(triggers), static_cast<TriggerKey>(info.vkCode)) != end(triggers))
             {
                 triggerPressed = info.vkCode;
-                const bool isLetterReleased = (GetAsyncKeyState((int)letterPressed) & 0x8000) == 0;
+                const bool isLetterReleased = (GetAsyncKeyState(static_cast<int>(letterPressed.load())) & 0x8000) == 0;
 
                 if (isLetterReleased ||
                     (triggerPressed == VK_SPACE && m_settings.activationKey == PowerAccentActivationKey::LeftRightArrow) ||
@@ -218,7 +218,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
         if (!m_toolbarVisible && letterPressed != LetterKey::None && triggerPressed && !IsSuppressedByGameMode() && !IsForegroundAppExcluded())
         {
-            Logger::debug(L"Show toolbar. Letter: {}, Trigger: {}", letterPressed, triggerPressed);
+            Logger::debug(L"Show toolbar. Letter: {}, Trigger: {}", letterPressed.load(), triggerPressed);
 
             // Keep track if it was triggered with space so that it can be typed on false starts.
             m_triggeredWithSpace = triggerPressed == VK_SPACE;

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "KeyboardListener.g.h"
+#include <atomic>
 #include <mutex>
 #include <spdlog/stopwatch.h>
 
@@ -53,18 +54,23 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
         static inline KeyboardListener* s_instance;
         HHOOK s_llKeyboardHook = nullptr;
-        bool m_toolbarVisible;
+        // State flags below are written from the LL keyboard hook thread (OnKeyDown/OnKeyUp)
+        // and from the UI/Dispatcher thread (ForceReset, via Selector_Deactivated). They are
+        // atomic so those accesses don't race. A mutex is intentionally avoided here: the
+        // PowerAccent.cs callbacks invoked from OnKeyDown/OnKeyUp Dispatcher.Invoke onto the UI
+        // thread, where ForceReset runs, so holding a lock across them would deadlock.
+        std::atomic<bool> m_toolbarVisible;
         PowerAccentSettings m_settings;
         std::function<void(LetterKey)> m_showToolbarCb;
         std::function<void(InputType)> m_hideToolbarCb;
         std::function<void(TriggerKey, bool)> m_nextCharCb;
         std::function<bool(LetterKey)> m_isLanguageLetterCb;
-        bool m_triggeredWithSpace;
-        bool m_triggeredWithLeftArrow;
-        bool m_triggeredWithRightArrow;
+        std::atomic<bool> m_triggeredWithSpace;
+        std::atomic<bool> m_triggeredWithLeftArrow;
+        std::atomic<bool> m_triggeredWithRightArrow;
         spdlog::stopwatch m_stopwatch;
-        bool m_leftShiftPressed;
-        bool m_rightShiftPressed;
+        std::atomic<bool> m_leftShiftPressed;
+        std::atomic<bool> m_rightShiftPressed;
 
         std::mutex m_mutex_excluded_apps;
         std::pair<HWND, bool> m_prevForegroundAppExcl{ NULL, false };
@@ -113,7 +119,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
                                                                LetterKey::VK_DIVIDE_,
                                                                LetterKey::VK_MULTIPLY_,
                                                                LetterKey::VK_BACKSLASH, };
-        LetterKey letterPressed{};
+        std::atomic<LetterKey> letterPressed{};
 
         static inline const std::vector<TriggerKey> triggers = { TriggerKey::Right, TriggerKey::Left, TriggerKey::Space };
     };

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
@@ -41,6 +41,8 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         void UpdateInputTime(int32_t inputTime);
         void UpdateExcludedApps(std::wstring_view excludedApps);
 
+        void ForceReset();
+
         static LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam);
 
     private:

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
@@ -84,6 +84,7 @@ namespace PowerToys
             void UpdateDoNotActivateOnGameMode(Boolean doNotActivateOnGameMode);
             void UpdateInputTime(Int32 inputTime);
             void UpdateExcludedApps(String excludedApps);
+            void ForceReset();
         }
     }
 }


### PR DESCRIPTION
## Summary

Add injection hygiene and focus-loss cleanup to PowerAccent (Quick Accent) to prevent cross-module stuck keys and stuck accent mode.

> **Note:** PR #46593 on `microsoft/PowerToys` is also touching PowerAccent with shift key state fixes. Coordinate before merging to avoid conflicts.

## Changes

### D1: Add `LLKHF_INJECTED` filter to LL keyboard hook
Skip injected events in `LowLevelKeyboardProc`. Prevents Keyboard Manager remapped keys from triggering accent mode — e.g., if KBM remaps Q to A, pressing Q should not activate the accent toolbar for 'A'.

### D2: Tag all `SendInput` output with `dwExtraInfo`
- Added `POWERTOYS_INJECTED_TAG = 0x110` constant
- Set `dwExtraInfo` on all `KEYBDINPUT` structs (backspace, character insertion)
- Added `SendInput` return value checking with error logging
- Other hooks (centralized, KBM) can now identify PowerAccent output and skip it

### D3: Add `ForceReset()` for focus-loss cleanup
- New `ForceReset()` method on `KeyboardListener` clears all state: `letterPressed`, `m_toolbarVisible`, trigger flags, shift flags
- Exposed through `PowerAccent.Core.ForceResetKeyboardState()`
- Wired into `Selector.OnDeactivated` — accent mode now cleans up when the window loses focus (Alt+Tab, click away, etc.)

### D4: Replace `SendKeys.SendWait` with tagged `SendInput`
- Replaced `SendKeys.SendWait("{RIGHT}")` / `"{LEFT}"` with `WindowsFunctions.SendArrowKey()`
- Uses tagged `SendInput` instead of blocking `SendKeys.SendWait`
- Arrow key events now carry `dwExtraInfo` so other hooks identify them as synthetic

## How to Reproduce
**D1 — Cross-module trigger:**
1. In KBM, remap Q to A
2. Press and hold Q, then press Space
3. **Before fix:** Accent toolbar appears for 'A' (triggered by KBM-injected input)
4. **After fix:** Accent toolbar does NOT appear (injected input filtered)

**D3 — Stuck accent mode:**
1. Trigger accent toolbar (hold a letter with accents, press Space)
2. While toolbar is visible, press Alt+Tab to switch apps
3. **Before fix:** Accent state stays active, Space/arrows swallowed globally
4. **After fix:** Toolbar hides, state resets on deactivation

## Coordination
- **PR #46593** on `microsoft/PowerToys` is also modifying PowerAccent shift state handling. Review both PRs together to avoid conflicts.

## PR Checklist
- [x] Builds clean on x64 Release
- [x] Manual verification per repro steps
- [x] No interference with KBM when both active
